### PR TITLE
Improve logging with structured output

### DIFF
--- a/collector/config.py
+++ b/collector/config.py
@@ -19,3 +19,4 @@ MAX_ROWS_PER_SYMBOL = int(os.environ.get('MAX_ROWS_PER_SYMBOL', 30_000))
 CSV_ARCHIVE_PATH = os.environ.get('CSV_ARCHIVE_PATH', 'csv_archives')
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
+LOG_FORMAT = os.environ.get('LOG_FORMAT', 'plain')

--- a/collector/data_integrity.py
+++ b/collector/data_integrity.py
@@ -189,6 +189,18 @@ class DataIntegrity:
                         self.logger.debug(
                             f"🆕 Inserting {len(missing)} empty candles for {start}→{end - self.delta}"
                         )
+                        ratio = len(missing) / len(expected_timestamps)
+                        if ratio > 0.2:
+                            self.logger.warning(
+                                "⚠️ More than 20% bars missing",
+                                extra={
+                                    "symbol": self.symbol,
+                                    "interval": self.interval,
+                                    "start": start,
+                                    "end": end - self.delta,
+                                    "missing_ratio": round(ratio, 3),
+                                },
+                            )
 
                 # реальные бары
                 real_rows = self._bars_to_rows(bars_in_gap)
@@ -333,9 +345,11 @@ class DataIntegrity:
             "limit":     limit
         }
         prepared = requests.Request("GET", url, params=params).prepare()
-        self.logger.debug(f"▶️ Request URL: {prepared.url}")
+        self.logger.debug(f"▶️ Binance request", extra={"url": prepared.url, "params": params})
         resp = requests.get(url, params=params, timeout=15)
-        self.logger.debug(f"🔹 Status: {resp.status_code}, length: {len(resp.text)}")
+        self.logger.debug(
+            f"🔹 Response", extra={"status": resp.status_code, "length": len(resp.text)}
+        )
         data = resp.json()
         if isinstance(data, list) and data:
             first_ts = pd.to_datetime(data[0][0], unit="ms", utc=True)
@@ -344,6 +358,11 @@ class DataIntegrity:
         elif isinstance(data, dict) and data.get("code"):
             self.logger.error(f"⚠️ Binance error: {data}")
             raise ValueError(f"Binance error: {data}")
+        elif isinstance(data, list) and not data:
+            self.logger.warning(
+                "⚠️ Binance returned 0 bars",
+                extra={"params": params}
+            )
         return data
 
     def _bars_to_rows(self, bars) -> list:

--- a/collector/logger.py
+++ b/collector/logger.py
@@ -1,0 +1,38 @@
+import os
+import json
+import logging
+from config import LOG_LEVEL, LOG_FORMAT
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "module": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        # include any additional attributes from "extra"
+        for key, value in record.__dict__.items():
+            if key not in ("name", "msg", "args", "levelname", "levelno", "pathname",
+                           "filename", "module", "exc_info", "exc_text", "stack_info",
+                           "lineno", "funcName", "created", "msecs", "relativeCreated",
+                           "thread", "threadName", "processName", "process", "message"):
+                log_record[key] = value
+        return json.dumps(log_record)
+
+
+def setup_logging() -> None:
+    """Configure root logging according to LOG_LEVEL and LOG_FORMAT."""
+    level = getattr(logging, LOG_LEVEL.upper(), logging.INFO)
+    handler = logging.StreamHandler()
+    if LOG_FORMAT.lower() == "json":
+        formatter = JsonFormatter()
+    else:
+        formatter = logging.Formatter(
+            "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+        )
+    handler.setFormatter(formatter)
+    logging.basicConfig(level=level, handlers=[handler])

--- a/collector/orchestrator.py
+++ b/collector/orchestrator.py
@@ -2,11 +2,12 @@ import logging
 import time
 import signal
 import sys
-from config import DB, SYMBOLS, INTERVALS, CSV_ARCHIVE_PATH, LOG_LEVEL, HIST_BARS
+from config import DB, SYMBOLS, INTERVALS, CSV_ARCHIVE_PATH, HIST_BARS
+from logger import setup_logging
 from db import get_conn, init_db
 from data_integrity import DataIntegrity
 
-logging.basicConfig(level=LOG_LEVEL)
+setup_logging()
 logger = logging.getLogger("orchestrator")
 
 SYNC_SLEEP_SEC = 60

--- a/collector/streamer_ws.py
+++ b/collector/streamer_ws.py
@@ -3,10 +3,11 @@ import json
 import logging
 import websockets
 from db import get_conn, insert_trade
-from config import DB, SYMBOLS, INTERVALS 
+from config import DB, SYMBOLS, INTERVALS
 from utils import normalize_timestamp
+from logger import setup_logging
 
-logging.basicConfig(level=logging.INFO)
+setup_logging()
 logger = logging.getLogger("ws_streamer")
 
 async def listen_symbol(symbol, interval):


### PR DESCRIPTION
## Summary
- centralize logging config with optional JSON format
- add `LOG_FORMAT` option in config
- use new logging setup in orchestrator and websocket streamer
- log binance fetch parameters and warn when bar gaps exceed 20%

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d9f449f088329b89010cc4a95f260